### PR TITLE
repo.url is api url

### DIFF
--- a/templates/assemble/repos-list.md
+++ b/templates/assemble/repos-list.md
@@ -1,5 +1,5 @@
 Here are some related projects you might be interested in from the [Assemble](http://assemble.io) core team.
 {% _.each(repos, function(repo) { %}
-+ [{%= repo.name %}]({%= repo.url %}): {%= repo.description %} {% }); %}
++ [{%= repo.name %}]({%= repo.html_url %}): {%= repo.description %} {% }); %}
 
 Visit [assemble.io/assemble-middleware](http:/assemble.io/assemble-middleware/) for more information about [Assemble](http:/assemble.io/) middleware.


### PR DESCRIPTION
`repo.url` returns api url such as `https://api.github.com/repos/assemble/assemble-plugin-blog`.
I think it might be replaced with `repo.html_url`.
